### PR TITLE
メモリリーク・例外安全性・循環参照対策の修正

### DIFF
--- a/Main.cpp
+++ b/Main.cpp
@@ -338,7 +338,7 @@ ScriptsAdd::getCount(tTJSVariant *result,
 {
 	if (numparams < 1) return TJS_E_BADPARAMCOUNT;
 	if (result) {
-		tjs_int count;
+		tjs_int count = 0;
 		param[0]->AsObjectClosureNoAddRef().GetCount(&count, NULL, NULL, NULL);
 		*result = count;
 	}
@@ -602,8 +602,10 @@ ScriptsAdd::getMD5HashString(tTJSVariant *result,
 							 tTJSVariant **param,
 							 iTJSDispatch2 *objthis) {
 	if (numparams < 1) return TJS_E_BADPARAMCOUNT;
+	if (param[0]->Type() != tvtOctet) return TJS_E_INVALIDPARAM;
 
 	tTJSVariantOctet *octet = param[0]->AsOctetNoAddRef();
+	if (!octet) return TJS_E_INVALIDPARAM;
 
 	TVP_md5_state_t st;
 	TVP_md5_init(&st);
@@ -759,6 +761,7 @@ ScriptsAdd::safeEvalStorage(tTJSVariant *result,
 							iTJSDispatch2 *objthis)
 {
 	if(numparams < 1) return TJS_E_BADPARAMCOUNT;
+	if (result) result->Clear();
 
 	ttstr name = *param[0];
 

--- a/Main.cpp
+++ b/Main.cpp
@@ -289,14 +289,26 @@ ScriptsAdd::_getKeys(tTJSVariant *result, tTJSVariant &obj)
 {
 	if (result) {
 		iTJSDispatch2 *array = TJSCreateArrayObject();
-		DictMemberGetCaller *caller = new DictMemberGetCaller(array);
-		tTJSVariantClosure closure(caller);
-		obj.AsObjectClosureNoAddRef().EnumMembers(TJS_IGNOREPROP|TJS_ENUM_NO_VALUE, &closure, NULL);
+		DictMemberGetCaller *caller;
+		try {
+			caller = new DictMemberGetCaller(array);
+		} catch(...) {
+			array->Release();
+			throw;
+		}
+		try {
+			tTJSVariantClosure closure(caller);
+			obj.AsObjectClosureNoAddRef().EnumMembers(TJS_IGNOREPROP|TJS_ENUM_NO_VALUE, &closure, NULL);
+			static tjs_uint sortHint = 0;
+			// 返すキーはソートする
+			array->FuncCall(0, TJS_W("sort"), &sortHint, 0, 0, 0, array);
+			*result = tTJSVariant(array, array);
+		} catch(...) {
+			caller->Release();
+			array->Release();
+			throw;
+		}
 		caller->Release();
-		static tjs_uint sortHint = 0;
-		// 返すキーはソートする
-		array->FuncCall(0, TJS_W("sort"), &sortHint, 0, 0, 0, array);
-		*result = tTJSVariant(array, array);
 		array->Release();
 	}
 }
@@ -405,9 +417,15 @@ ScriptsAdd::equalStruct(tTJSVariant v1, tTJSVariant v2)
 			}
 			// 全項目を順番に比較
 			DictMemberCompareCaller *caller = new DictMemberCompareCaller(o2);
-			tTJSVariantClosure closure(caller);
-			tTJSVariant(o1.EnumMembers(TJS_IGNOREPROP, &closure, NULL));
-			bool result = caller->match;
+			bool result;
+			try {
+				tTJSVariantClosure closure(caller);
+				tTJSVariant(o1.EnumMembers(TJS_IGNOREPROP, &closure, NULL));
+				result = caller->match;
+			} catch(...) {
+				caller->Release();
+				throw;
+			}
 			caller->Release();
 			return result;
 		}
@@ -467,9 +485,15 @@ ScriptsAdd::equalStructNumericLoose(tTJSVariant v1, tTJSVariant v2)
 				return false;
 			// 全項目を順番に比較
 			DictMemberCompareNumericLooseCaller *caller = new DictMemberCompareNumericLooseCaller(o2);
-			tTJSVariantClosure closure(caller);
-			tTJSVariant(o1.EnumMembers(TJS_IGNOREPROP, &closure, NULL));
-			bool result = caller->match;
+			bool result;
+			try {
+				tTJSVariantClosure closure(caller);
+				tTJSVariant(o1.EnumMembers(TJS_IGNOREPROP, &closure, NULL));
+				result = caller->match;
+			} catch(...) {
+				caller->Release();
+				throw;
+			}
 			caller->Release();
 			return result;
 		}
@@ -508,45 +532,59 @@ ScriptsAdd::foreach(tTJSVariant *result,
 
 		tTJSVariant key, value;
 		tTJSVariant **paramList = new tTJSVariant *[numparams];
-		paramList[0] = &key;
-		paramList[1] = &value;
-		for (tjs_int i = 2; i < numparams; i++)
-			paramList[i] = param[i];
+		try {
+			paramList[0] = &key;
+			paramList[1] = &value;
+			for (tjs_int i = 2; i < numparams; i++)
+				paramList[i] = param[i];
 
-		tTJSVariant arrayCount;
-		(void)obj.PropGet(0, TJS_W("count"), &countHint, &arrayCount, NULL);
-		tjs_int count = arrayCount;
+			tTJSVariant arrayCount;
+			(void)obj.PropGet(0, TJS_W("count"), &countHint, &arrayCount, NULL);
+			tjs_int count = arrayCount;
 
-		tTJSVariant breakResult;
-		for (tjs_int i = 0; i < count; i++) {
-			key = i;
-			breakResult.Clear();
-			(void)obj.PropGetByNum(TJS_IGNOREPROP, i, &value, NULL);
-			(void)func->FuncCall(0, NULL, NULL, &breakResult, numparams, paramList, functhis);
-			if (breakResult.Type() != tvtVoid) {
-				break;
+			tTJSVariant breakResult;
+			for (tjs_int i = 0; i < count; i++) {
+				key = i;
+				breakResult.Clear();
+				(void)obj.PropGetByNum(TJS_IGNOREPROP, i, &value, NULL);
+				(void)func->FuncCall(0, NULL, NULL, &breakResult, numparams, paramList, functhis);
+				if (breakResult.Type() != tvtVoid) {
+					break;
+				}
 			}
+			if (result) {
+				*result = breakResult;
+			}
+		} catch(...) {
+			delete[] paramList;
+			throw;
 		}
-		if (result) {
-			*result = breakResult;
-		}
-		
 		delete[] paramList;
 
 	} else {
 
 		tTJSVariant **paramList = new tTJSVariant *[numparams];
-		for (tjs_int i = 2; i < numparams; i++)
-			paramList[i] = param[i];
-
-		DictIterateCaller *caller = new DictIterateCaller(func, functhis, paramList, numparams);
-		tTJSVariantClosure closure(caller);
-		obj.EnumMembers(TJS_IGNOREPROP, &closure, NULL);
-		if (result) {
-			*result = caller->breakResult;
+		DictIterateCaller *caller;
+		try {
+			for (tjs_int i = 2; i < numparams; i++)
+				paramList[i] = param[i];
+			caller = new DictIterateCaller(func, functhis, paramList, numparams);
+		} catch(...) {
+			delete[] paramList;
+			throw;
+		}
+		try {
+			tTJSVariantClosure closure(caller);
+			obj.EnumMembers(TJS_IGNOREPROP, &closure, NULL);
+			if (result) {
+				*result = caller->breakResult;
+			}
+		} catch(...) {
+			caller->Release();
+			delete[] paramList;
+			throw;
 		}
 		caller->Release();
-
 		delete[] paramList;
 	}
 	return TJS_S_OK;
@@ -625,28 +663,45 @@ ScriptsAdd::clone(tTJSVariant obj)
 		// Arrayの複製
 		if (o1.IsInstanceOf(0, NULL, NULL, TJS_W("Array"), NULL)== TJS_S_TRUE) {
 			iTJSDispatch2 *array = TJSCreateArrayObject();
-			tTJSVariant o1Count;
-			(void)o1.PropGet(0, TJS_W("count"), &countHint, &o1Count, NULL);
-			tjs_int count = o1Count;
-			tTJSVariant val;
-			tTJSVariant *args[] = {&val};
-			for (tjs_int i = 0; i < count; i++) {
-				(void)o1.PropGetByNum(TJS_IGNOREPROP, i, &val, NULL);
-				val = ScriptsAdd::clone(val);
-				static tjs_uint addHint = 0;
-				(void)array->FuncCall(0, TJS_W("add"), &addHint, 0, 1, args, array);
+			try {
+				tTJSVariant o1Count;
+				(void)o1.PropGet(0, TJS_W("count"), &countHint, &o1Count, NULL);
+				tjs_int count = o1Count;
+				tTJSVariant val;
+				tTJSVariant *args[] = {&val};
+				for (tjs_int i = 0; i < count; i++) {
+					(void)o1.PropGetByNum(TJS_IGNOREPROP, i, &val, NULL);
+					val = ScriptsAdd::clone(val);
+					static tjs_uint addHint = 0;
+					(void)array->FuncCall(0, TJS_W("add"), &addHint, 0, 1, args, array);
+				}
+				tTJSVariant result(array, array);
+				array->Release();
+				return result;
+			} catch(...) {
+				array->Release();
+				throw;
 			}
-			tTJSVariant result(array, array);
-			array->Release();
-			return result;
 		}
-		
+
 		// Dictionaryの複製
 		if (o1.IsInstanceOf(0, NULL, NULL, TJS_W("Dictionary"), NULL)== TJS_S_TRUE) {
 			iTJSDispatch2 *dict = TJSCreateDictionaryObject();
-			DictMemberCloneCaller *caller = new DictMemberCloneCaller(dict);
-			tTJSVariantClosure closure(caller);
-			o1.EnumMembers(TJS_IGNOREPROP, &closure, NULL);
+			DictMemberCloneCaller *caller;
+			try {
+				caller = new DictMemberCloneCaller(dict);
+			} catch(...) {
+				dict->Release();
+				throw;
+			}
+			try {
+				tTJSVariantClosure closure(caller);
+				o1.EnumMembers(TJS_IGNOREPROP, &closure, NULL);
+			} catch(...) {
+				caller->Release();
+				dict->Release();
+				throw;
+			}
 			caller->Release();
 			tTJSVariant result(dict, dict);
 			dict->Release();

--- a/Main.cpp
+++ b/Main.cpp
@@ -143,9 +143,9 @@ public:
 												iTJSDispatch2 *objthis		// object as "this"
 												) {
 		if (numparams > 1) {
-			tTVInteger flag = param[1]->AsInteger();
+			tTVInteger memberFlag = param[1]->AsInteger();
 			static tjs_uint addHint = 0;
-			if (!(flag & TJS_HIDDENMEMBER)) {
+			if (!(memberFlag & TJS_HIDDENMEMBER)) {
 				array->FuncCall(0, TJS_W("add"), &addHint, 0, 1, &param[0], array);
 			}
 		}
@@ -158,26 +158,6 @@ protected:
 	iTJSDispatch2 *array;
 };
 
-
-//----------------------------------------------------------------------
-// 辞書を作成
-tTJSVariant createDictionary(void)
-{
-	iTJSDispatch2 *obj = TJSCreateDictionaryObject();
-	tTJSVariant result(obj, obj);
-	obj->Release();
-	return result;
-}
-
-//----------------------------------------------------------------------
-// 配列を作成
-tTJSVariant createArray(void)
-{
-	iTJSDispatch2 *obj = TJSCreateArrayObject();
-	tTJSVariant result(obj, obj);
-	obj->Release();
-	return result;
-}
 
 //----------------------------------------------------------------------
 // 辞書の要素を全比較するCaller

--- a/Main.cpp
+++ b/Main.cpp
@@ -2,8 +2,38 @@
 #include <vector>
 #include <algorithm>
 #include <cstring>
+#include <set>
+#include <map>
+#include <utility>
 
 #include "bitap_fuzzy.hpp"
+
+//----------------------------------------------------------------------
+// 循環参照検出用 visited (thread_local + RAII)
+// equalStruct / clone の再帰中に同じ Dispatch ペア / Dispatch を再訪したら
+// 「等しい」もしくは「既存クローン」を返してスタックオーバーフロー回避。
+namespace {
+	struct EqualVisited {
+		typedef std::pair<iTJSDispatch2*, iTJSDispatch2*> KeyT;
+		typedef std::set<KeyT> SetT;
+		static thread_local int depth;
+		static thread_local SetT seen;
+		EqualVisited() { if (depth == 0) seen.clear(); ++depth; }
+		~EqualVisited() { --depth; if (depth == 0) seen.clear(); }
+	};
+	thread_local int EqualVisited::depth = 0;
+	thread_local EqualVisited::SetT EqualVisited::seen;
+
+	struct CloneVisited {
+		typedef std::map<iTJSDispatch2*, iTJSDispatch2*> MapT;
+		static thread_local int depth;
+		static thread_local MapT seen;
+		CloneVisited() { if (depth == 0) seen.clear(); ++depth; }
+		~CloneVisited() { --depth; if (depth == 0) seen.clear(); }
+	};
+	thread_local int CloneVisited::depth = 0;
+	thread_local CloneVisited::MapT CloneVisited::seen;
+}
 
 /**
  * メソッド追加用
@@ -370,11 +400,19 @@ ScriptsAdd::isNullContext(tTJSVariant obj)
 bool
 ScriptsAdd::equalStruct(tTJSVariant v1, tTJSVariant v2)
 {
+	EqualVisited scope;
 	// タイプがオブジェクトなら特殊判定
 	if (v1.Type() == tvtObject
 		&& v2.Type() == tvtObject) {
-		if (v1.AsObjectNoAddRef() == v2.AsObjectNoAddRef())
+		iTJSDispatch2 *p1 = v1.AsObjectNoAddRef();
+		iTJSDispatch2 *p2 = v2.AsObjectNoAddRef();
+		if (p1 == p2)
 			return true;
+
+		// 循環: 既に (p1,p2) を比較中なら同型とみなして true を返す
+		EqualVisited::KeyT key(p1, p2);
+		if (EqualVisited::seen.count(key)) return true;
+		EqualVisited::seen.insert(key);
 
 		tTJSVariantClosure &o1 = v1.AsObjectClosureNoAddRef();
 		tTJSVariantClosure &o2 = v2.AsObjectClosureNoAddRef();
@@ -439,11 +477,19 @@ ScriptsAdd::equalStruct(tTJSVariant v1, tTJSVariant v2)
 bool
 ScriptsAdd::equalStructNumericLoose(tTJSVariant v1, tTJSVariant v2)
 {
+	EqualVisited scope;
 	// タイプがオブジェクトなら特殊判定
 	if (v1.Type() == tvtObject
 		&& v2.Type() == tvtObject) {
-		if (v1.AsObjectNoAddRef() == v2.AsObjectNoAddRef())
+		iTJSDispatch2 *p1 = v1.AsObjectNoAddRef();
+		iTJSDispatch2 *p2 = v2.AsObjectNoAddRef();
+		if (p1 == p2)
 			return true;
+
+		// 循環: 既に (p1,p2) を比較中なら同型とみなして true を返す
+		EqualVisited::KeyT key(p1, p2);
+		if (EqualVisited::seen.count(key)) return true;
+		EqualVisited::seen.insert(key);
 
 		tTJSVariantClosure &o1 = v1.AsObjectClosureNoAddRef();
 		tTJSVariantClosure &o2 = v2.AsObjectClosureNoAddRef();
@@ -656,15 +702,26 @@ protected:
 tTJSVariant
 ScriptsAdd::clone(tTJSVariant obj)
 {
+	CloneVisited scope;
 	// タイプがオブジェクトなら細かく判定
 	if (obj.Type() == tvtObject) {
 
 		tTJSVariantClosure &o1 = obj.AsObjectClosureNoAddRef();
 		if (!o1.Object) return obj; // nullなら無視
 
+		// 循環: 既にクローン済の source なら同じクローンを返す
+		{
+			CloneVisited::MapT::iterator it = CloneVisited::seen.find(o1.Object);
+			if (it != CloneVisited::seen.end()) {
+				iTJSDispatch2 *cloned = it->second;
+				return tTJSVariant(cloned, cloned);
+			}
+		}
+
 		// Arrayの複製
 		if (o1.IsInstanceOf(0, NULL, NULL, TJS_W("Array"), NULL)== TJS_S_TRUE) {
 			iTJSDispatch2 *array = TJSCreateArrayObject();
+			CloneVisited::seen[o1.Object] = array;
 			try {
 				tTJSVariant o1Count;
 				(void)o1.PropGet(0, TJS_W("count"), &countHint, &o1Count, NULL);
@@ -689,6 +746,7 @@ ScriptsAdd::clone(tTJSVariant obj)
 		// Dictionaryの複製
 		if (o1.IsInstanceOf(0, NULL, NULL, TJS_W("Dictionary"), NULL)== TJS_S_TRUE) {
 			iTJSDispatch2 *dict = TJSCreateDictionaryObject();
+			CloneVisited::seen[o1.Object] = dict;
 			DictMemberCloneCaller *caller;
 			try {
 				caller = new DictMemberCloneCaller(dict);


### PR DESCRIPTION
## 概要

`Main.cpp` のコードレビューで見つかった以下の問題を 4 コミットに分けて修正しました。

1. **例外パスでのリーク** (`2393b4d`) — `EnumMembers` / `PropGet*` / `FuncCall` 等が throw した場合に裸の `new` で確保した Dispatch Caller / `iTJSDispatch2` / `paramList[]` が漏れる箇所を try-catch で塞ぐ
2. **引数バリデーション強化** (`ed68b59`) — `getMD5HashString` の octet 非チェック (NULL deref クラッシュ)、`getCount` の未初期化値書き込み、`safeEvalStorage` の result 持ち越し
3. **循環参照対策** (`3ad8fa1`) — `equalStruct` / `equalStructNumericLoose` / `clone` に自己参照構造を渡すと無限再帰 → スタックオーバーフローしていたのを、thread_local + RAII の visited scope で回避
4. **クリーンアップ** (`29087fd`) — シャドウ変数 1 件のリネーム + 呼ばれていないファイルスコープ関数 (`createDictionary` / `createArray`) の削除

## 詳細

### 1. 例外パスでのリーク (5 関数)

`tTJSDispatch2` 由来のメソッドはスクリプト側 Caller (`DictMemberGetCaller` 等) が throw する余地があります。元コードは

```cpp
DictMemberCompareCaller *caller = new DictMemberCompareCaller(o2);
tTJSVariantClosure closure(caller);
tTJSVariant(o1.EnumMembers(TJS_IGNOREPROP, &closure, NULL));  // ← throw すると caller 漏れる
bool result = caller->match;
caller->Release();
```

の形で、`EnumMembers` 等の throw で caller / array / paramList[] が漏れていました。tjs2 監査でやった `Dictionary::forEach` と同型の修正を機械的に当てています。

対象:
- `_getKeys` — `DictMemberGetCaller` + array
- `equalStruct` Dict 比較 — `DictMemberCompareCaller`
- `equalStructNumericLoose` Dict 比較 — `DictMemberCompareNumericLooseCaller`
- `foreach` — Array/Dict 経路の `paramList[]` + `DictIterateCaller`
- `clone` — Array/Dict 経路の一時 array / `DictMemberCloneCaller` / dict

OOM や深い再帰中の throw など発火頻度の低い経路ですが latent leak。

### 2. 引数バリデーション

- **`getMD5HashString`**: `param[0]->AsOctetNoAddRef()` を型チェックせず直接 deref していたので、octet 以外を渡すと NULL deref で SIGSEGV。`Type() != tvtOctet` で `TJS_E_INVALIDPARAM` を返すように。
- **`getCount`**: `tjs_int count;` を初期化せず `GetCount` の戻り値も見ずに `*result = count` していたので、`GetCount` 失敗時に未初期化値を書き込む可能性。`= 0` で初期化。
- **`safeEvalStorage`**: `TVPExecuteExpression` 後に `clo.Object` が NULL のとき `*result` が前値を引きずる挙動。先頭で `result->Clear()`。

### 3. 循環参照対策

自己参照を含む配列／辞書を渡すと `equalStruct` / `clone` が無限再帰で SO クラッシュしていました。

thread_local + RAII の visited scope を導入し、再帰の最上位で seen を clear、再帰中は同じ thread_local set/map を参照する仕組みにしました。

- `EqualVisited`: `(iTJSDispatch2*, iTJSDispatch2*)` の set。再帰中に同じペアを再訪したら同型とみなして true を返す
- `CloneVisited`: source → cloned の map。clone 入口で既存クローンがあればそれを返し、Array/Dict 作成時に `seen[source] = new` に登録

これにより自己参照構造でも SO を起こさず、`clone` は循環構造を循環クローンとして再現します。

シングルスレッドの TJS から呼ばれるので thread_local は本来不要ですが、念のため将来のマルチスレッド呼び出しでも汚染しないようにしてあります。

**制約**: 「visited に再訪したら等しいとみなす」簡易ポリシーのため、構造が違うが両方循環するペアを誤って equal と判定するケースはありえます。SO クラッシュ回避が主目的のため許容しています。

### 4. クリーンアップ

- `DictMemberGetCaller::FuncCall`: ローカル `tTVInteger flag` が引数 `tjs_uint32 flag` をシャドウしていたのを `memberFlag` にリネーム (動作変更なし)
- `createDictionary` / `createArray` (ファイルスコープ関数): どこからも呼ばれていないデッドコードを削除

## ビルド確認

各コミット後に `cmake --build build/x64-windows --config Release --target scriptsEx` で `scriptsEx.dll` のリンクまで確認しています (MSVC, krkrz_dev umbrella ビルド)。

## 動作確認

機能的なリグレッションテストは未実施です (リーク修正は例外パス上にあり通常パスは経路同一、循環参照は新規の安定化)。マージ前に Linux / 通常データでの動作確認をお願いできるとありがたいです。